### PR TITLE
cura5: fix package for wayland

### DIFF
--- a/pkgs/by-name/cu/cura5/package.nix
+++ b/pkgs/by-name/cu/cura5/package.nix
@@ -33,7 +33,7 @@ let
       fi
       args+=("$a")
     done
-    exec "${cura5}/bin/cura5" "''${args[@]}"
+    QT_QPA_PLATFORM=xcb exec "${cura5}/bin/cura5" "''${args[@]}"
   '';
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
Cura5 doesn't run under Wayland, using `QT_QPA_PLATFORM=xcb` helped. See https://github.com/NixOS/nixpkgs/issues/186570#issuecomment-2526277637.